### PR TITLE
Inherit from default face for `face-background`

### DIFF
--- a/magit-blame-color-by-age.el
+++ b/magit-blame-color-by-age.el
@@ -66,7 +66,7 @@ Defaults to the full buffer."
 	   (hformat (magit-blame--style-get 'heading-format))
 	   (string-key (list hformat '(magit-blame-heading default)))
 	   (age-key (if (string-search "%C" hformat) "committer-time" "author-time"))
-	   (back-col (color-name-to-rgb (face-background 'magit-blame-heading)))
+	   (back-col (color-name-to-rgb (face-background 'magit-blame-heading nil t)))
 	   (from-col (color-name-to-rgb (car mbc/colors)))
 	   (to-col (color-name-to-rgb (cdr mbc/colors)))
 	   age-min age-rng)


### PR DESCRIPTION
I'm new to elisp. I see that `magit-blame-heading` inherits from `magit-blame-highlight` and hence should have a background color defined. However, on my system (GNU Emacs 30.1 (build 1, x86_64-apple-darwin24.3.0, NS appkit-2575.40 Version 15.3 (Build 24D60))), `(face-background 'magit-blame-heading)` returns `nil`. Should we fall back to default colors in that case?